### PR TITLE
Feature/signup and login

### DIFF
--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -41,4 +41,5 @@ input loginUserInput {
 type Mutation {
   createUser(input: createUserInput!): User!
   loginUser(input: loginUserInput!): User!
+  logoutUser: Boolean
 }

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -24,6 +24,7 @@ type Prefecture {
 
 type Query {
   getPrefectures: [Prefecture!]!
+  getCurrentUser: User
 }
 
 input createUserInput {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -93,6 +93,14 @@ func (r *queryResolver) GetPrefectures(ctx context.Context) ([]*model.Prefecture
 	return res, nil
 }
 
+func (r *queryResolver) GetCurrentUser(ctx context.Context) (*model.User, error) {
+	user := auth.ForContext(ctx)
+	if user == nil {
+		return nil, nil
+	}
+	return user, nil
+}
+
 // Mutation returns generated.MutationResolver implementation.
 func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResolver{r} }
 

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -69,10 +69,19 @@ func (r *mutationResolver) LoginUser(ctx context.Context, input model.LoginUserI
 
 	res, err := u.AuthenticateUser(r.client.User, ctx)
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 
+	token, _ := user.CreateToken(res.ID)
+
+	auth.SetAuthCookie(ctx, token)
+
 	return res, nil
+}
+
+func (r *mutationResolver) LogoutUser(ctx context.Context) (*bool, error) {
+	auth.RemoveAuthCookie(ctx)
+	return nil, nil
 }
 
 func (r *queryResolver) GetPrefectures(ctx context.Context) ([]*model.Prefecture, error) {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -5,10 +5,10 @@ package graph
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/nagokos/connefut_backend/auth"
 	"github.com/nagokos/connefut_backend/graph/domain/prefecture"
 	"github.com/nagokos/connefut_backend/graph/domain/user"
 	"github.com/nagokos/connefut_backend/graph/generated"
@@ -18,7 +18,6 @@ import (
 )
 
 func (r *mutationResolver) CreateUser(ctx context.Context, input model.CreateUserInput) (*model.User, error) {
-	fmt.Println(input.Name)
 	u := user.User{
 		Name:     input.Name,
 		Email:    input.Email,
@@ -39,10 +38,13 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input model.CreateUse
 	}
 
 	res, err := u.CreateUser(r.client.User, ctx)
-
 	if err != nil {
-		return res, err
+		return &model.User{}, err
 	}
+
+	token, _ := user.CreateToken(res.ID)
+
+	auth.SetAuthCookie(ctx, token)
 
 	return res, nil
 }
@@ -52,8 +54,6 @@ func (r *mutationResolver) LoginUser(ctx context.Context, input model.LoginUserI
 		Email:    input.Email,
 		Password: input.Password,
 	}
-
-	fmt.Println(u)
 
 	err := u.AuthenticateUserValidate()
 	if err != nil {


### PR DESCRIPTION
## やったこと
ログインユーザー取得のクエリを追加
ログアウトのミューテーションを追加
ログインユーザー取得の処理を実装
ログアウトの処理を実装
ユーザー作成後にCookieにjwtをセット

## やらないこと
特になし

## できるようになること（ユーザ目線）
ログインユーザーが返されるようになる
ログアウトできるようになる
ユーザー作成後にjwtがセットされるようになる(ログイン状態を保持)

## できなくなること（ユーザ目線）
特になし

## 動作確認
ログインユーザーが帰ってくることを確認
ログアウトできることを確認
ユーザー作成後にjwtがセットされていることを確認

## その他
特になし
