### PR TITLE
Feature/create recruiement

### DIFF
--- a/graph/domain/recruitment/recruitment.go
+++ b/graph/domain/recruitment/recruitment.go
@@ -1,0 +1,107 @@
+package recruitment
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/nagokos/connefut_backend/auth"
+	"github.com/nagokos/connefut_backend/ent"
+	"github.com/nagokos/connefut_backend/ent/recruitment"
+	"github.com/nagokos/connefut_backend/graph/model"
+	"github.com/nagokos/connefut_backend/logger"
+)
+
+type Recruitment struct {
+	Title         string
+	Type          model.Type
+	Level         model.Level
+	Place         *string
+	StartAt       *time.Time
+	Content       string
+	LocationURL   *string
+	Capacity      *int
+	ClosingAt     time.Time
+	CompetitionID string
+	PrefectureID  string
+}
+
+func (r Recruitment) CreateRecruitmentValidate() error {
+	return validation.ValidateStruct(&r,
+		validation.Field(
+			&r.Title,
+			validation.Required.Error("タイトルを入力してください"),
+			validation.RuneLength(1, 60).Error("エラーです"),
+		),
+		validation.Field(
+			&r.Type,
+			validation.Required.Error("募集タイプを選択してください"),
+		),
+		validation.Field(
+			&r.Content,
+			validation.Required.Error("募集の詳細を入力してください"),
+			validation.RuneLength(1, 10000).Error("募集の詳細は10000文字以内で入力してください"),
+		),
+		validation.Field(
+			&r.PrefectureID,
+			validation.Required.Error("募集エリアを選択してください"),
+		),
+		validation.Field(
+			&r.CompetitionID,
+			validation.Required.Error("募集競技を選択してください"),
+		),
+	)
+}
+
+func (r *Recruitment) CreateRecruitment(ctx context.Context, client *ent.RecruitmentClient) (*model.Recruitment, error) {
+	currentUser := auth.ForContext(ctx)
+
+	res, err := client.
+		Create().
+		SetTitle(r.Title).
+		SetType(recruitment.Type(strings.ToLower(string(r.Type)))).
+		SetLevel(recruitment.Level(strings.ToLower(string(r.Level)))).
+		SetNillableCapacity(r.Capacity).
+		SetNillableStartAt(r.StartAt).
+		SetContent(r.Content).
+		SetNillablePlace(r.Place).
+		SetNillableLocationURL(r.LocationURL).
+		SetClosingAt(r.ClosingAt).
+		SetCompetitionID(r.CompetitionID).
+		SetPrefectureID(r.PrefectureID).
+		SetUserID(currentUser.ID).
+		Save(ctx)
+	if err != nil {
+		logger.Log.Error().Msg(fmt.Sprintln("recruitment create errors:", err.Error()))
+		return &model.Recruitment{}, err
+	}
+
+	c, _ := res.Competition(ctx)
+	p, _ := res.Prefecture(ctx)
+
+	resRecruitment := &model.Recruitment{
+		ID:          res.ID,
+		Title:       res.Title,
+		Type:        model.Type(res.Type),
+		Level:       model.Level(res.Level),
+		Place:       &res.Place,
+		StartAt:     &res.StartAt,
+		Content:     res.Content,
+		LocationURL: &res.LocationURL,
+		Capacity:    &res.Capacity,
+		ClosingAt:   res.ClosingAt,
+		Competition: &model.Competition{
+			ID:   c.ID,
+			Name: c.Name,
+		},
+		Prefecture: &model.Prefecture{
+			ID:   p.ID,
+			Name: p.Name,
+		},
+		User: currentUser,
+	}
+
+	return resRecruitment, nil
+}

--- a/graph/domain/user/user.go
+++ b/graph/domain/user/user.go
@@ -158,6 +158,7 @@ func (u *User) CreateUser(client *ent.UserClient, ctx context.Context) (user *mo
 		EmailVerificationStatus: model.EmailVerificationStatus(res.EmailVerificationStatus),
 	}
 
+	// 本番環境と開発環境では違う
 	SendVerifyEmail(emailToken)
 
 	if err != nil {

--- a/graph/domain/user/user.go
+++ b/graph/domain/user/user.go
@@ -110,7 +110,7 @@ func CreateToken(userID string) (string, error) {
 	token := jwt.New(jwt.SigningMethodHS256)
 	token.Claims = jwt.MapClaims{
 		"user_id": userID,
-		"exp":     time.Now().Add(time.Hour * 1).Unix(),
+		"exp":     time.Now().Add(time.Hour * 24).Unix(),
 	}
 	tokenString, err := token.SignedString([]byte("secretKey"))
 	if err != nil {

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
@@ -49,9 +50,10 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CreateUser func(childComplexity int, input model.CreateUserInput) int
-		LoginUser  func(childComplexity int, input model.LoginUserInput) int
-		LogoutUser func(childComplexity int) int
+		CreateRecruitment func(childComplexity int, input model.CreateRecruitmentInput) int
+		CreateUser        func(childComplexity int, input model.CreateUserInput) int
+		LoginUser         func(childComplexity int, input model.LoginUserInput) int
+		LogoutUser        func(childComplexity int) int
 	}
 
 	Prefecture struct {
@@ -63,6 +65,22 @@ type ComplexityRoot struct {
 		GetCompetitions func(childComplexity int) int
 		GetCurrentUser  func(childComplexity int) int
 		GetPrefectures  func(childComplexity int) int
+	}
+
+	Recruitment struct {
+		Capacity    func(childComplexity int) int
+		ClosingAt   func(childComplexity int) int
+		Competition func(childComplexity int) int
+		Content     func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Level       func(childComplexity int) int
+		LocationURL func(childComplexity int) int
+		Place       func(childComplexity int) int
+		Prefecture  func(childComplexity int) int
+		StartAt     func(childComplexity int) int
+		Title       func(childComplexity int) int
+		Type        func(childComplexity int) int
+		User        func(childComplexity int) int
 	}
 
 	User struct {
@@ -80,6 +98,7 @@ type MutationResolver interface {
 	CreateUser(ctx context.Context, input model.CreateUserInput) (*model.User, error)
 	LoginUser(ctx context.Context, input model.LoginUserInput) (*model.User, error)
 	LogoutUser(ctx context.Context) (*bool, error)
+	CreateRecruitment(ctx context.Context, input model.CreateRecruitmentInput) (*model.Recruitment, error)
 }
 type QueryResolver interface {
 	GetPrefectures(ctx context.Context) ([]*model.Prefecture, error)
@@ -115,6 +134,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Competition.Name(childComplexity), true
+
+	case "Mutation.createRecruitment":
+		if e.complexity.Mutation.CreateRecruitment == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createRecruitment_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateRecruitment(childComplexity, args["input"].(model.CreateRecruitmentInput)), true
 
 	case "Mutation.createUser":
 		if e.complexity.Mutation.CreateUser == nil {
@@ -181,6 +212,97 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.GetPrefectures(childComplexity), true
+
+	case "Recruitment.capacity":
+		if e.complexity.Recruitment.Capacity == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Capacity(childComplexity), true
+
+	case "Recruitment.closingAt":
+		if e.complexity.Recruitment.ClosingAt == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.ClosingAt(childComplexity), true
+
+	case "Recruitment.competition":
+		if e.complexity.Recruitment.Competition == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Competition(childComplexity), true
+
+	case "Recruitment.content":
+		if e.complexity.Recruitment.Content == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Content(childComplexity), true
+
+	case "Recruitment.id":
+		if e.complexity.Recruitment.ID == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.ID(childComplexity), true
+
+	case "Recruitment.level":
+		if e.complexity.Recruitment.Level == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Level(childComplexity), true
+
+	case "Recruitment.locationUrl":
+		if e.complexity.Recruitment.LocationURL == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.LocationURL(childComplexity), true
+
+	case "Recruitment.place":
+		if e.complexity.Recruitment.Place == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Place(childComplexity), true
+
+	case "Recruitment.prefecture":
+		if e.complexity.Recruitment.Prefecture == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Prefecture(childComplexity), true
+
+	case "Recruitment.startAt":
+		if e.complexity.Recruitment.StartAt == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.StartAt(childComplexity), true
+
+	case "Recruitment.title":
+		if e.complexity.Recruitment.Title == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Title(childComplexity), true
+
+	case "Recruitment.type":
+		if e.complexity.Recruitment.Type == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.Type(childComplexity), true
+
+	case "Recruitment.user":
+		if e.complexity.Recruitment.User == nil {
+			break
+		}
+
+		return e.complexity.Recruitment.User(childComplexity), true
 
 	case "User.avatar":
 		if e.complexity.User.Avatar == nil {
@@ -299,6 +421,8 @@ var sources = []*ast.Source{
 #
 # https://gqlgen.com/getting-started/
 
+scalar DateTime
+
 enum Role {
   ADMIN
   GENERAL
@@ -308,6 +432,24 @@ enum EmailVerificationStatus {
   UNNECESSARY
   PENDING
   VERIFIED
+}
+
+enum Type {
+  OPPONENT
+  INDIVIDUAL
+  TEAMMATE
+  JOINING
+  COACHING
+  OTHERS
+}
+
+enum Level {
+  UNNECESSARY
+  ENJOY
+  BEGINNER
+  MIDDLE
+  EXPERT
+  OPEN
 }
 
 type User {
@@ -330,6 +472,22 @@ type Competition {
   name: String!
 }
 
+type Recruitment {
+  id: String!
+  title: String!
+  content: String!
+  type: Type!
+  level: Level!
+  place: String
+  startAt: DateTime
+  locationUrl: String
+  capacity: Int
+  closingAt: DateTime!
+  competition: Competition!
+  prefecture: Prefecture!
+  user: User!
+}
+
 type Query {
   getPrefectures: [Prefecture!]!
   getCurrentUser: User
@@ -347,10 +505,25 @@ input loginUserInput {
   password: String!
 }
 
+input createRecruitmentInput {
+  title: String!
+  content: String!
+  type: Type!
+  level: Level!
+  place: String
+  startAt: DateTime
+  locationUrl: String
+  capacity: Int
+  closingAt: DateTime!
+  competitionId: String!
+  prefectureId: String!
+}
+
 type Mutation {
   createUser(input: createUserInput!): User!
   loginUser(input: loginUserInput!): User!
   logoutUser: Boolean
+  createRecruitment(input: createRecruitmentInput!): Recruitment!
 }
 `, BuiltIn: false},
 }
@@ -359,6 +532,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_createRecruitment_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.CreateRecruitmentInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNcreateRecruitmentInput2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐCreateRecruitmentInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_createUser_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -644,6 +832,48 @@ func (ec *executionContext) _Mutation_logoutUser(ctx context.Context, field grap
 	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Mutation_createRecruitment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createRecruitment_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateRecruitment(rctx, args["input"].(model.CreateRecruitmentInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Recruitment)
+	fc.Result = res
+	return ec.marshalNRecruitment2ᚖgithubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐRecruitment(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Prefecture_id(ctx context.Context, field graphql.CollectedField, obj *model.Prefecture) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -885,6 +1115,449 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	res := resTmp.(*introspection.Schema)
 	fc.Result = res
 	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_id(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_title(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_content(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Content, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_type(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Type)
+	fc.Result = res
+	return ec.marshalNType2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_level(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Level, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Level)
+	fc.Result = res
+	return ec.marshalNLevel2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐLevel(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_place(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Place, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_startAt(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StartAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODateTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_locationUrl(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LocationURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_capacity(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Capacity, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_closingAt(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ClosingAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDateTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_competition(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Competition, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Competition)
+	fc.Result = res
+	return ec.marshalNCompetition2ᚖgithubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐCompetition(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_prefecture(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Prefecture, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Prefecture)
+	fc.Result = res
+	return ec.marshalNPrefecture2ᚖgithubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐPrefecture(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Recruitment_user(ctx context.Context, field graphql.CollectedField, obj *model.Recruitment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Recruitment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.User, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.User)
+	fc.Result = res
+	return ec.marshalNUser2ᚖgithubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
@@ -2258,6 +2931,109 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputcreateRecruitmentInput(ctx context.Context, obj interface{}) (model.CreateRecruitmentInput, error) {
+	var it model.CreateRecruitmentInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "title":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("title"))
+			it.Title, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "content":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("content"))
+			it.Content, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "type":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
+			it.Type, err = ec.unmarshalNType2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐType(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "level":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("level"))
+			it.Level, err = ec.unmarshalNLevel2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐLevel(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "place":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("place"))
+			it.Place, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "startAt":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("startAt"))
+			it.StartAt, err = ec.unmarshalODateTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "locationUrl":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("locationUrl"))
+			it.LocationURL, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "capacity":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("capacity"))
+			it.Capacity, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "closingAt":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("closingAt"))
+			it.ClosingAt, err = ec.unmarshalNDateTime2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "competitionId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("competitionId"))
+			it.CompetitionID, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "prefectureId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("prefectureId"))
+			it.PrefectureID, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputcreateUserInput(ctx context.Context, obj interface{}) (model.CreateUserInput, error) {
 	var it model.CreateUserInput
 	asMap := map[string]interface{}{}
@@ -2395,6 +3171,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "logoutUser":
 			out.Values[i] = ec._Mutation_logoutUser(ctx, field)
+		case "createRecruitment":
+			out.Values[i] = ec._Mutation_createRecruitment(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -2496,6 +3277,81 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Values[i] = ec._Query___type(ctx, field)
 		case "__schema":
 			out.Values[i] = ec._Query___schema(ctx, field)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var recruitmentImplementors = []string{"Recruitment"}
+
+func (ec *executionContext) _Recruitment(ctx context.Context, sel ast.SelectionSet, obj *model.Recruitment) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, recruitmentImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Recruitment")
+		case "id":
+			out.Values[i] = ec._Recruitment_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "title":
+			out.Values[i] = ec._Recruitment_title(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "content":
+			out.Values[i] = ec._Recruitment_content(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "type":
+			out.Values[i] = ec._Recruitment_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "level":
+			out.Values[i] = ec._Recruitment_level(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "place":
+			out.Values[i] = ec._Recruitment_place(ctx, field, obj)
+		case "startAt":
+			out.Values[i] = ec._Recruitment_startAt(ctx, field, obj)
+		case "locationUrl":
+			out.Values[i] = ec._Recruitment_locationUrl(ctx, field, obj)
+		case "capacity":
+			out.Values[i] = ec._Recruitment_capacity(ctx, field, obj)
+		case "closingAt":
+			out.Values[i] = ec._Recruitment_closingAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "competition":
+			out.Values[i] = ec._Recruitment_competition(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "prefecture":
+			out.Values[i] = ec._Recruitment_prefecture(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "user":
+			out.Values[i] = ec._Recruitment_user(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -2880,6 +3736,21 @@ func (ec *executionContext) marshalNCompetition2ᚖgithubᚗcomᚋnagokosᚋconn
 	return ec._Competition(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNDateTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
+	res, err := model.UnmarshalDateTime(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDateTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	res := model.MarshalDateTime(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNEmailVerificationStatus2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐEmailVerificationStatus(ctx context.Context, v interface{}) (model.EmailVerificationStatus, error) {
 	var res model.EmailVerificationStatus
 	err := res.UnmarshalGQL(v)
@@ -2887,6 +3758,16 @@ func (ec *executionContext) unmarshalNEmailVerificationStatus2githubᚗcomᚋnag
 }
 
 func (ec *executionContext) marshalNEmailVerificationStatus2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐEmailVerificationStatus(ctx context.Context, sel ast.SelectionSet, v model.EmailVerificationStatus) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNLevel2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐLevel(ctx context.Context, v interface{}) (model.Level, error) {
+	var res model.Level
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNLevel2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐLevel(ctx context.Context, sel ast.SelectionSet, v model.Level) graphql.Marshaler {
 	return v
 }
 
@@ -2944,6 +3825,20 @@ func (ec *executionContext) marshalNPrefecture2ᚖgithubᚗcomᚋnagokosᚋconne
 	return ec._Prefecture(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNRecruitment2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐRecruitment(ctx context.Context, sel ast.SelectionSet, v model.Recruitment) graphql.Marshaler {
+	return ec._Recruitment(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNRecruitment2ᚖgithubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐRecruitment(ctx context.Context, sel ast.SelectionSet, v *model.Recruitment) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Recruitment(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNRole2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐRole(ctx context.Context, v interface{}) (model.Role, error) {
 	var res model.Role
 	err := res.UnmarshalGQL(v)
@@ -2967,6 +3862,16 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNType2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐType(ctx context.Context, v interface{}) (model.Type, error) {
+	var res model.Type
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNType2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐType(ctx context.Context, sel ast.SelectionSet, v model.Type) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v model.User) graphql.Marshaler {
@@ -3240,6 +4145,11 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 	return res
 }
 
+func (ec *executionContext) unmarshalNcreateRecruitmentInput2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐCreateRecruitmentInput(ctx context.Context, v interface{}) (model.CreateRecruitmentInput, error) {
+	res, err := ec.unmarshalInputcreateRecruitmentInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNcreateUserInput2githubᚗcomᚋnagokosᚋconnefut_backendᚋgraphᚋmodelᚐCreateUserInput(ctx context.Context, v interface{}) (model.CreateUserInput, error) {
 	res, err := ec.unmarshalInputcreateUserInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -3272,6 +4182,36 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 		return graphql.Null
 	}
 	return graphql.MarshalBoolean(*v)
+}
+
+func (ec *executionContext) unmarshalODateTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := model.UnmarshalDateTime(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalODateTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return model.MarshalDateTime(*v)
+}
+
+func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalInt(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return graphql.MarshalInt(*v)
 }
 
 func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {

--- a/graph/model/datetime.go
+++ b/graph/model/datetime.go
@@ -15,6 +15,9 @@ import (
 func UnmarshalDateTime(v interface{}) (time.Time, error) {
 	switch v := v.(type) {
 	case string:
+		if len(v) == 0 {
+			return time.Time{}, nil
+		}
 		return time.Parse("2006/01/02 15:04", v)
 	case time.Time:
 		return v, nil

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 )
 
 type Competition struct {
@@ -18,6 +19,22 @@ type Prefecture struct {
 	Name string `json:"name"`
 }
 
+type Recruitment struct {
+	ID          string       `json:"id"`
+	Title       string       `json:"title"`
+	Content     string       `json:"content"`
+	Type        Type         `json:"type"`
+	Level       Level        `json:"level"`
+	Place       *string      `json:"place"`
+	StartAt     *time.Time   `json:"startAt"`
+	LocationURL *string      `json:"locationUrl"`
+	Capacity    *int         `json:"capacity"`
+	ClosingAt   time.Time    `json:"closingAt"`
+	Competition *Competition `json:"competition"`
+	Prefecture  *Prefecture  `json:"prefecture"`
+	User        *User        `json:"user"`
+}
+
 type User struct {
 	ID                      string                  `json:"id"`
 	Name                    string                  `json:"name"`
@@ -26,6 +43,20 @@ type User struct {
 	Avatar                  string                  `json:"avatar"`
 	Introduction            *string                 `json:"introduction"`
 	EmailVerificationStatus EmailVerificationStatus `json:"emailVerificationStatus"`
+}
+
+type CreateRecruitmentInput struct {
+	Title         string     `json:"title"`
+	Content       string     `json:"content"`
+	Type          Type       `json:"type"`
+	Level         Level      `json:"level"`
+	Place         *string    `json:"place"`
+	StartAt       *time.Time `json:"startAt"`
+	LocationURL   *string    `json:"locationUrl"`
+	Capacity      *int       `json:"capacity"`
+	ClosingAt     time.Time  `json:"closingAt"`
+	CompetitionID string     `json:"competitionId"`
+	PrefectureID  string     `json:"prefectureId"`
 }
 
 type CreateUserInput struct {
@@ -82,6 +113,55 @@ func (e EmailVerificationStatus) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+type Level string
+
+const (
+	LevelUnnecessary Level = "UNNECESSARY"
+	LevelEnjoy       Level = "ENJOY"
+	LevelBeginner    Level = "BEGINNER"
+	LevelMiddle      Level = "MIDDLE"
+	LevelExpert      Level = "EXPERT"
+	LevelOpen        Level = "OPEN"
+)
+
+var AllLevel = []Level{
+	LevelUnnecessary,
+	LevelEnjoy,
+	LevelBeginner,
+	LevelMiddle,
+	LevelExpert,
+	LevelOpen,
+}
+
+func (e Level) IsValid() bool {
+	switch e {
+	case LevelUnnecessary, LevelEnjoy, LevelBeginner, LevelMiddle, LevelExpert, LevelOpen:
+		return true
+	}
+	return false
+}
+
+func (e Level) String() string {
+	return string(e)
+}
+
+func (e *Level) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = Level(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid Level", str)
+	}
+	return nil
+}
+
+func (e Level) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type Role string
 
 const (
@@ -120,5 +200,54 @@ func (e *Role) UnmarshalGQL(v interface{}) error {
 }
 
 func (e Role) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type Type string
+
+const (
+	TypeOpponent   Type = "OPPONENT"
+	TypeIndividual Type = "INDIVIDUAL"
+	TypeTeammate   Type = "TEAMMATE"
+	TypeJoining    Type = "JOINING"
+	TypeCoaching   Type = "COACHING"
+	TypeOthers     Type = "OTHERS"
+)
+
+var AllType = []Type{
+	TypeOpponent,
+	TypeIndividual,
+	TypeTeammate,
+	TypeJoining,
+	TypeCoaching,
+	TypeOthers,
+}
+
+func (e Type) IsValid() bool {
+	switch e {
+	case TypeOpponent, TypeIndividual, TypeTeammate, TypeJoining, TypeCoaching, TypeOthers:
+		return true
+	}
+	return false
+}
+
+func (e Type) String() string {
+	return string(e)
+}
+
+func (e *Type) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = Type(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid Type", str)
+	}
+	return nil
+}
+
+func (e Type) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -2,6 +2,8 @@
 #
 # https://gqlgen.com/getting-started/
 
+scalar DateTime
+
 enum Role {
   ADMIN
   GENERAL

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -86,8 +86,23 @@ input loginUserInput {
   password: String!
 }
 
+input createRecruitmentInput {
+  title: String!
+  content: String!
+  type: Type!
+  level: Level!
+  place: String
+  startAt: DateTime
+  locationUrl: String
+  capacity: Int
+  closingAt: DateTime!
+  competitionId: String!
+  prefectureId: String!
+}
+
 type Mutation {
   createUser(input: createUserInput!): User!
   loginUser(input: loginUserInput!): User!
   logoutUser: Boolean
+  createRecruitment(input: createRecruitmentInput!): Recruitment!
 }

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -15,6 +15,24 @@ enum EmailVerificationStatus {
   VERIFIED
 }
 
+enum Type {
+  OPPONENT
+  INDIVIDUAL
+  TEAMMATE
+  JOINING
+  COACHING
+  OTHERS
+}
+
+enum Level {
+  UNNECESSARY
+  ENJOY
+  BEGINNER
+  MIDDLE
+  EXPERT
+  OPEN
+}
+
 type User {
   id: String!
   name: String!

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -53,6 +53,22 @@ type Competition {
   name: String!
 }
 
+type Recruitment {
+  id: String!
+  title: String!
+  content: String!
+  type: Type!
+  level: Level!
+  place: String
+  startAt: DateTime
+  locationUrl: String
+  capacity: Int
+  closingAt: DateTime!
+  competition: Competition!
+  prefecture: Prefecture!
+  user: User!
+}
+
 type Query {
   getPrefectures: [Prefecture!]!
   getCurrentUser: User


### PR DESCRIPTION
## やったこと
Datetimeカスタムスカラーを作成("yyyy/mm/dd hh:mm")の形で受け取り、この形で返却する
level Enumを作成
type Recruitmentを作成
募集作成のミューテーションをインプットを作成
meke generateコマンドを実行
Datetimeスカラーで空文字が送られてきた時に、エラーが出ないように対応
募集作成のロジックを作成
jwtの有効期限を24時間に修正
コメントを追加

## やらないこと
特になし

## できるようになること（ユーザ目線）
募集の作成ができるようになる
ログイン状態が24時間保持されるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
カスタムスカラーが想定通りに動くことを確認
募集が作成できることを確認
jwtの有効期限が24時間になっていることを確認

## その他
特になし
